### PR TITLE
Clear form after submission

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -226,6 +226,7 @@ $(document).ready(function () {
                     } else {
                         $('#alert-wrapper').html('');
                         $('#rsvp-modal').modal('show');
+                        $('#rsvp-form')[0].reset();
                     }
                 })
                 .fail(function (data) {


### PR DESCRIPTION
I had a number of non-technical users feel that because the boxes did not clear after submission it had not "sent" successfully - despite the modal pop-up.

Also if one person is RSVPing for multiple people, leaving the boxes filled adds score for errors and frustrations.